### PR TITLE
Add configuration  checkbox for source tag

### DIFF
--- a/src/org/openstreetmap/josm/plugins/areaselector/AreaSelectorAction.java
+++ b/src/org/openstreetmap/josm/plugins/areaselector/AreaSelectorAction.java
@@ -65,13 +65,15 @@ public class AreaSelectorAction extends MapMode implements MouseListener {
     protected double toleranceDist = ImageAnalyzer.DEFAULT_TOLERANCEDIST,
             toleranceAngle = ImageAnalyzer.DEFAULT_TOLERANCEANGLE;
 
-    protected boolean showAddressDialog = true, mergeNodes = true, useAustriaAdressHelper = false, replaceBuildings = true;
+    protected boolean showAddressDialog = true, mergeNodes = true, useAustriaAdressHelper = false,
+            replaceBuildings = true, addSourceTag = false;
 
     public static final String PLUGIN_NAME = "areaselector";
 
     public static final String KEY_SHOWADDRESSDIALOG = PLUGIN_NAME + ".showaddressdialog",
             KEY_MERGENODES = PLUGIN_NAME + ".mergenodes", KEY_AAH = PLUGIN_NAME + ".austriaadresshelper",
-            KEY_REPLACEBUILDINGS = PLUGIN_NAME + ".replacebuildings";
+            KEY_REPLACEBUILDINGS = PLUGIN_NAME + ".replacebuildings",
+            KEY_ADDSOURCETAG = PLUGIN_NAME + ".addsourcetag";
 
     protected Logger log = LogManager.getLogger(AreaSelectorAction.class.getCanonicalName());
 
@@ -92,6 +94,7 @@ public class AreaSelectorAction extends MapMode implements MouseListener {
         this.showAddressDialog = new BooleanProperty(KEY_SHOWADDRESSDIALOG, true).get();
         useAustriaAdressHelper = new BooleanProperty(KEY_AAH, false).get();
         replaceBuildings = new BooleanProperty(KEY_REPLACEBUILDINGS, true).get();
+        addSourceTag = new BooleanProperty(KEY_ADDSOURCETAG, false).get();
     }
 
     private static Cursor getCursor() {
@@ -199,7 +202,7 @@ public class AreaSelectorAction extends MapMode implements MouseListener {
 
             way.put(AddressDialog.TAG_BUILDING, new StringProperty(AddressDialog.PREF_BUILDING, "yes").get());
 
-            if (!showAddressDialog) {
+            if (!showAddressDialog && addSourceTag) {
                 ArrayList<String> sources = new ArrayList<>();
                 for (Layer layer : mapView.getLayerManager().getVisibleLayersInZOrder()) {
                     if (layer.isVisible() && layer.isBackgroundLayer()) {

--- a/src/org/openstreetmap/josm/plugins/areaselector/preferences/PreferencesPanel.java
+++ b/src/org/openstreetmap/josm/plugins/areaselector/preferences/PreferencesPanel.java
@@ -49,6 +49,8 @@ public class PreferencesPanel extends JPanel {
 
 	private JCheckBox ckbxReplaceBuilding;
 
+	private JCheckBox ckbxAddSourceTag;
+
 	/**
 	 * Constructs a new {@code PreferencesPanel}.
 	 */
@@ -109,6 +111,9 @@ public class PreferencesPanel extends JPanel {
 
 		ckbxReplaceBuilding = new JCheckBox("<html><p><b>" + tr("Replace existing buildings") + "</b></p></html>");
 		this.addCheckbox(tr("Replace an existing building with the new one."), ckbxReplaceBuilding);
+
+		ckbxAddSourceTag = new JCheckBox("<html><p><b>" + tr("Add source tag") + "</b></p></html>");
+		this.addCheckbox(tr("Add source tag."), ckbxAddSourceTag);
 
 		ckbxDebug = new JCheckBox("<html><p><b>" + tr("Debug") + "</b></p></html>");
 		this.addCheckbox(tr("Debugging mode will write images for each processing step."), ckbxDebug);
@@ -190,6 +195,7 @@ public class PreferencesPanel extends JPanel {
 		new BooleanProperty(ImageAnalyzer.KEY_DEBUG, false).put(ckbxDebug.isSelected());
 		new BooleanProperty(AreaSelectorAction.KEY_AAH, false).put(ckbxAustriaAdressHelper.isSelected());
 		new BooleanProperty(AreaSelectorAction.KEY_REPLACEBUILDINGS, true).put(ckbxReplaceBuilding.isSelected());
+		new BooleanProperty(AreaSelectorAction.KEY_ADDSOURCETAG, false).put(ckbxAddSourceTag.isSelected());
 	}
 
 	/**
@@ -211,5 +217,6 @@ public class PreferencesPanel extends JPanel {
 		algorithm.setSelectedIndex(algorithmIdx < algorithm.getMaximumRowCount() ? algorithmIdx : ImageAnalyzer.DEFAULT_ALGORITHM);
 		ckbxDebug.setSelected(new BooleanProperty(ImageAnalyzer.KEY_DEBUG, false).get());
 		ckbxReplaceBuilding.setSelected(new BooleanProperty(AreaSelectorAction.KEY_REPLACEBUILDINGS, true).get());
+		ckbxAddSourceTag.setSelected(new BooleanProperty(AreaSelectorAction.KEY_ADDSOURCETAG, false).get());
 	}
 }


### PR DESCRIPTION
This patch allow user to select adding source tag or not.
In recent habitat, it is not recommended to add source tag for each POI. 
It is better to add source in commit log.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>