### PR TITLE
Update gradle and josm plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,10 @@
 import com.github.spotbugs.SpotBugsTask
 import net.ltgt.gradle.errorprone.*
-import org.openstreetmap.josm.gradle.plugin.config.I18nConfig
-import org.openstreetmap.josm.gradle.plugin.config.JosmManifest
 import org.openstreetmap.josm.gradle.plugin.task.MarkdownToHtml
 import java.net.URL
 
 plugins {
-    id("org.openstreetmap.josm") version "0.6.2"
+    id("org.openstreetmap.josm") version "0.7.1"
     id("com.github.spotbugs") version "2.0.0"
     id("net.ltgt.errorprone") version "0.8.1"
     java
@@ -129,14 +127,18 @@ pmd {
 }
 
 josm {
+    pluginName = "areaselector"
     i18n {
-        pathTransformer = getPathTransformer("github.com/JOSM/areaselector/blob")
+        pathTransformer = getPathTransformer(project.projectDir, "github.com/JOSM/areaselector/blob")
     }
     manifest {
         pluginDependencies.add("austriaaddresshelper")
         pluginDependencies.add("ejml")
         pluginDependencies.add("log4j")
-    }
+        oldVersionDownloadLink(15017, "v2.5.1", URL("https://github.com/JOSM/areaselector/releases/download/v2.5.1/areaselector.jar"))
+        oldVersionDownloadLink(12859, "v2.4.9", URL("https://github.com/JOSM/areaselector/releases/download/v2.4.9/areaselector.jar"))
+        oldVersionDownloadLink(11226, "v2.4.3", URL("https://github.com/JOSM/areaselector/releases/download/v2.4.3/areaselector.jar"))
+  }
 }
 
 tasks.withType(JavaCompile::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ plugin.main.version=15017
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=15322
+plugin.compile.version=16871
 plugin.canloadatruntime=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- use gradle 6.1.1
- josm plugin 0.7.1
- build with josm 16871
- add backword compatible version link

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
