### PR TITLE
Combobox fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,12 +20,13 @@ base.archivesBaseName = "areaselector"
 
 val versions = mapOf(
     "austriaaddresshelper" to "v0.8.0",
+    // Note: boofcv 0.39.1 is NOT Java 8 compatible
     "boofcv" to "0.39",
     "ddogleg" to "0.20",
-    "errorprone" to "2.9.0",
-    "junit" to "5.8.1",
+    "errorprone" to "2.10.0",
+    "junit" to "5.8.2",
     "pmd" to "6.18.0",
-    "spotbugs" to "4.4.2",
+    "spotbugs" to "4.5.2",
     "xmlpull" to "1.1.3.1",
     "xpp" to "1.1.6",
     "xstream" to "1.4.18"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,10 +22,8 @@ val versions = mapOf(
     "austriaaddresshelper" to "v0.8.0",
     "boofcv" to "0.39",
     "ddogleg" to "0.20",
-    "ejml" to "0.41",
     "errorprone" to "2.9.0",
     "junit" to "5.8.1",
-    "log4j" to "2.16.0",
     "pmd" to "6.18.0",
     "spotbugs" to "4.4.2",
     "xmlpull" to "1.1.3.1",
@@ -36,6 +34,8 @@ val versions = mapOf(
 repositories {
     jcenter()
     mavenCentral()
+    // Note: This may become unnecessary in future josm gradle plugin versions.
+    // See https://gitlab.com/floscher/gradle-josm-plugin/-/merge_requests/9
     ivy {
         url = uri("https://github.com/JOSM/austriaaddresshelper/releases/download/")
         content {
@@ -83,11 +83,8 @@ val libsImplementation by configurations.getting {
 
 dependencies {
     packIntoJar("com.thoughtworks.xstream:xstream:${versions["xstream"]}")
-    packIntoJar("org.ejml:ejml-core:${versions["ejml"]}")
     packIntoJar("org.ogce:xpp3:${versions["xpp"]}")
     packIntoJar("xmlpull:xmlpull:${versions["xmlpull"]}")
-    implementation("org.apache.logging.log4j:log4j-api:${versions["log4j"]}")
-    implementation("org.apache.logging.log4j:log4j-core:${versions["log4j"]}")
 
     packIntoJar("org.boofcv:boofcv-core:${versions["boofcv"]}")
     packIntoJar("org.boofcv:boofcv-feature:${versions["boofcv"]}")
@@ -105,7 +102,6 @@ dependencies {
     libsImplementation("org.boofcv:boofcv-io:${versions["boofcv"]}")
     libsImplementation("org.ddogleg:ddogleg:${versions["ddogleg"]}")
 
-    testImplementation ("org.openstreetmap.josm:josm-unittest:SNAPSHOT"){ isChanging = true }
     testImplementation("org.junit.jupiter:junit-jupiter-api:${versions["junit"]}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${versions["junit"]}")
     testImplementation("com.github.spotbugs:spotbugs-annotations:${versions["spotbugs"]}")
@@ -151,9 +147,7 @@ josm {
         pathTransformer = getPathTransformer(project.projectDir, "github.com/JOSM/areaselector/blob")
     }
     manifest {
-        pluginDependencies.add("austriaaddresshelper")
-        pluginDependencies.add("ejml")
-        pluginDependencies.add("log4j")
+        oldVersionDownloadLink(16871, "v2.6.0-beta.1", URL("https://github.com/JOSM/areaselector/releases/download/v2.6.0-beta.1/areaselector.jar"))
         oldVersionDownloadLink(15017, "v2.5.1", URL("https://github.com/JOSM/areaselector/releases/download/v2.5.1/areaselector.jar"))
         oldVersionDownloadLink(12859, "v2.4.9", URL("https://github.com/JOSM/areaselector/releases/download/v2.4.9/areaselector.jar"))
         oldVersionDownloadLink(11226, "v2.4.3", URL("https://github.com/JOSM/areaselector/releases/download/v2.4.3/areaselector.jar"))

--- a/build.xml
+++ b/build.xml
@@ -1,48 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project name="areaselector" default="dist" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
 
-	<!-- enter the SVN commit message -->
-	<property name="commit.message" value="Commit message" />
+  <!-- enter the SVN commit message -->
+  <property name="commit.message" value="Commit message" />
 
-	<!-- Configure these properties (replace "..." accordingly).
-         See https://josm.openstreetmap.de/wiki/DevelopersGuide/DevelopingPlugins
-     -->
-    <!-- edit the properties of this plugin in the file `gradle.properties` -->
-    <property file="${basedir}/gradle.properties"/>
+  <!-- Configure these properties (replace "..." accordingly).
+       See https://josm.openstreetmap.de/wiki/DevelopersGuide/DevelopingPlugins
+  -->
+  <!-- edit the properties of this plugin in the file `gradle.properties` -->
+  <property file="${basedir}/gradle.properties"/>
 
-	<path id="ivy.lib.path" path="ant/ivy-2.5.0.jar" />
-	<taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path" />
-
-	<!-- ** include targets that all plugins have in common ** -->
-	<import file="../build-common.xml" />
+  <!-- ** include targets that all plugins have in common ** -->
+  <import file="../build-common.xml" />
 
     <fileset id="plugin.requires.jars" dir="${plugin.dist.dir}">
+        <include name="austriaaddresshelper.jar"/>
+        <include name="ejml.jar"/>
         <include name="log4j.jar"/>
-    	<include name="austriaaddresshelper.jar"/>
     </fileset>
 
     <target name="pre-compile" depends="fetch_dependencies">
         <!-- include fetch_dependencies task -->
     </target>
-	
-	<target name="fetch_dependencies" depends="clean_ivy">
-		<echo>fetching dependencies with ivy</echo>
-		<ivy:retrieve pattern="${plugin.lib.dir}/[artifact]-[type].[ext]" conf="default" />
-	</target>
 
-	<target name="clean_ivy">
-		<delete failonerror="false">
-			<fileset dir="${plugin.lib.dir}">
-				<include name="**/*.jar"/>
-				<exclude name="**/*-custom.jar" />
-			</fileset>
-		</delete>
-	</target>
+  <target name="install-plugin" depends="clean, dist, install">
+    <echo>Installed areaselector plugin</echo>
+  </target>
 
-	<target name="install-plugin" depends="clean, dist, install">
-		<echo>Installed areaselector plugin</echo>
-	</target>
-	
-	<target name="test-run" depends="install-plugin, runjosm">
-	</target>
+  <target name="test-run" depends="install-plugin, runjosm">
+  </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -14,13 +14,14 @@
   <import file="../build-common.xml" />
 
     <fileset id="plugin.requires.jars" dir="${plugin.dist.dir}">
-        <include name="austriaaddresshelper.jar"/>
-        <include name="ejml.jar"/>
-        <include name="log4j.jar"/>
+      <include name="apache-commons.jar"/>
+      <include name="austriaaddresshelper.jar"/>
+      <include name="ejml.jar"/>
+      <include name="log4j.jar"/>
     </fileset>
 
     <target name="pre-compile" depends="fetch_dependencies">
-        <!-- include fetch_dependencies task -->
+      <!-- include fetch_dependencies task -->
     </target>
 
   <target name="install-plugin" depends="clean, dist, install">

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ plugin.link=https://github.com/JOSM/areaselector
 plugin.requires=log4j;austriaaddresshelper;ejml
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
 # You can check if the plugin compiles against this version by executing `./gradlew minJosmVersionClasses`.
-plugin.main.version=15017
+plugin.main.version=18173
 # Version of JOSM against which the plugin is compiled
 # Please check, if the specified version is available for download from https://josm.openstreetmap.de/download/ .
 # If not, choose the next higher number that is available, or the gradle build will break.
-plugin.compile.version=18303
+plugin.compile.version=18173
 plugin.canloadatruntime=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ plugin.author=Paul Woelfel, Thomas Konrad
 plugin.class=org.openstreetmap.josm.plugins.areaselector.AreaSelectorPlugin
 plugin.icon=images/mapmode/areaselector.png
 plugin.link=https://github.com/JOSM/areaselector
-plugin.requires=log4j;austriaaddresshelper;ejml
+plugin.requires=apache-commons;austriaaddresshelper;ejml;log4j
 # Minimum required JOSM version to run this plugin, choose the lowest version possible that is compatible.
 # You can check if the plugin compiles against this version by executing `./gradlew minJosmVersionClasses`.
 plugin.main.version=18173

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,14 +1,15 @@
 <ivy-module version="2.0">
-	<info organisation="org.openstreetmap.josm.plugins" module="areaselector" revision="2.2.0" />
-	<configurations defaultconf="default" defaultconfmapping="default->default,sources,javadoc">
-		<conf name="default" />
-	</configurations>
-	<dependencies>
-		<dependency org="org.boofcv" name="boofcv-core" rev="0.39"/>
-		<dependency org="org.boofcv" name="boofcv-feature" rev="0.39"/>
-		<dependency org="org.boofcv" name="boofcv-swing" rev="0.39"/>
-		<dependency org="org.boofcv" name="boofcv-ip" rev="0.39"/>
-		<dependency org="org.boofcv" name="boofcv-io" rev="0.39"/>
-
-	</dependencies>
+  <info organisation="org.openstreetmap.josm.plugins" module="areaselector" revision="2.2.0" />
+  <configurations defaultconf="default" defaultconfmapping="default->default,sources,javadoc">
+    <conf name="default" />
+  </configurations>
+  <dependencies>
+    <dependency org="org.boofcv" name="boofcv-core" rev="0.39"/>
+    <dependency org="org.boofcv" name="boofcv-feature" rev="0.39"/>
+    <dependency org="org.boofcv" name="boofcv-swing" rev="0.39"/>
+    <dependency org="org.boofcv" name="boofcv-ip" rev="0.39"/>
+    <dependency org="org.boofcv" name="boofcv-io" rev="0.39"/>
+    <!-- from ejml plugin -->
+    <exclude org="org.ejml"/>
+  </dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -11,5 +11,8 @@
     <dependency org="org.boofcv" name="boofcv-io" rev="0.39"/>
     <!-- from ejml plugin -->
     <exclude org="org.ejml"/>
+    <!-- from apache-commons plugin -->
+    <exclude org="org.apache.commons" module="commons-compress"/>
+    <exclude org="commons-io" module="commons-io"/>
   </dependencies>
 </ivy-module>

--- a/src/org/openstreetmap/josm/plugins/areaselector/AddressDialog.java
+++ b/src/org/openstreetmap/josm/plugins/areaselector/AddressDialog.java
@@ -42,7 +42,7 @@ import org.openstreetmap.josm.data.tagging.ac.AutoCompletionSet;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.Layer;
-import org.openstreetmap.josm.gui.tagging.ac.AutoCompletingComboBox;
+import org.openstreetmap.josm.gui.tagging.ac.AutoCompComboBox;
 import org.openstreetmap.josm.gui.tagging.ac.AutoCompletionManager;
 import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.GBC;
@@ -82,7 +82,7 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
     protected JTextField houseNumField;
     protected ButtonGroup houseNumChange;
 
-    protected AutoCompletingComboBox streetNameField, cityField, postCodeField, countryField, houseNameField, buildingField, tagsField, sourceField;
+    protected AutoCompComboBox<AutoCompletionItem> streetNameField, cityField, postCodeField, countryField, houseNameField, buildingField, tagsField, sourceField;
 
     protected static final String[] BUTTON_TEXTS = new String[] {tr("OK"), tr("Cancel")};
     protected static final String[] BUTTON_ICONS = new String[] {"ok", "cancel"};
@@ -125,8 +125,8 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
 
         AutoCompletionManager acm = AutoCompletionManager.of(OsmDataManager.getInstance().getEditDataSet());
 
-        houseNameField = new AutoCompletingComboBox();
-        houseNameField.setPossibleAcItems(acm.getTagValues(TAG_HOUSENAME));
+        houseNameField = new AutoCompComboBox<>();
+        houseNameField.getModel().addAllElements(acm.getTagValues(TAG_HOUSENAME));
         houseNameField.setEditable(true);
 
         houseNumField = new JTextField();
@@ -177,29 +177,29 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
         });
         houseNumPanel.add(skip);
 
-        streetNameField = new AutoCompletingComboBox();
-        streetNameField.setPossibleAcItems(acm.getTagValues(TAG_STREETNAME));
+        streetNameField = new AutoCompComboBox<>();
+        streetNameField.getModel().addAllElements(acm.getTagValues(TAG_STREETNAME));
         streetNameField.setEditable(true);
         streetNameField.setSelectedItem(Config.getPref().get(PREF_STREETNAME));
 
-        cityField = new AutoCompletingComboBox();
-        cityField.setPossibleAcItems(acm.getTagValues(TAG_CITY));
+        cityField = new AutoCompComboBox<>();
+        cityField.getModel().addAllElements(acm.getTagValues(TAG_CITY));
         cityField.setEditable(true);
         cityField.setSelectedItem(Config.getPref().get(PREF_CITY));
 
-        postCodeField = new AutoCompletingComboBox();
-        postCodeField.setPossibleAcItems(acm.getTagValues(TAG_POSTCODE));
+        postCodeField = new AutoCompComboBox<>();
+        postCodeField.getModel().addAllElements(acm.getTagValues(TAG_POSTCODE));
         postCodeField.setEditable(true);
         postCodeField.setSelectedItem(Config.getPref().get(PREF_POSTCODE));
 
-        countryField = new AutoCompletingComboBox();
-        countryField.setPossibleAcItems(acm.getTagValues(TAG_COUNTRY));
+        countryField = new AutoCompComboBox<>();
+        countryField.getModel().addAllElements(acm.getTagValues(TAG_COUNTRY));
         countryField.setEditable(true);
         countryField.setSelectedItem(Config.getPref().get(PREF_COUNTRY));
 
 
-        buildingField = new AutoCompletingComboBox();
-        buildingField.setPossibleAcItems(acm.getTagValues(TAG_BUILDING));
+        buildingField = new AutoCompComboBox<>();
+        buildingField.getModel().addAllElements(acm.getTagValues(TAG_BUILDING));
         buildingField.setEditable(true);
         buildingField.setSelectedItem(Config.getPref().get(PREF_BUILDING));
 
@@ -226,12 +226,12 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
         }
 
 
-        tagsField = new AutoCompletingComboBox();
-        tagsField.setPossibleAcItems(aciTags);
+        tagsField = new AutoCompComboBox<>();
+        tagsField.getModel().addAllElements(aciTags);
         tagsField.setEditable(true);
         tagsField.setSelectedItem(otherTags.length() > 0 ? otherTags : Config.getPref().get(PREF_TAGS));
 
-        sourceField = new AutoCompletingComboBox();
+        sourceField = new AutoCompComboBox<>();
         AutoCompletionSet sourceValues = acm.getTagValues(TAG_SOURCE);
 
         ArrayList<String> sources = new ArrayList<>();
@@ -241,12 +241,12 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
             }
         }
         Collections.reverse(sources);
-        String source = sources.stream().map(Object::toString).collect(Collectors.joining("; ")).toString();
+        String source = sources.stream().map(Object::toString).collect(Collectors.joining("; "));
         if (!source.isEmpty()) {
             sourceValues.add(new AutoCompletionItem(source));
         }
 
-        sourceField.setPossibleAcItems(sourceValues);
+        sourceField.getModel().addAllElements(sourceValues);
         sourceField.setEditable(true);
         sourceField.setPreferredSize(new Dimension(400, 24));
         sourceField.setSelectedItem(Config.getPref().get(PREF_SOURCE));
@@ -281,8 +281,8 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
         fields.addAll(Arrays.asList(fieldArr));
 
         for (Component field: fields){
-            if (field instanceof AutoCompletingComboBox){
-                AutoCompletingComboBox combox = (AutoCompletingComboBox) field;
+            if (field instanceof AutoCompComboBox){
+                AutoCompComboBox<?> combox = (AutoCompComboBox<?>) field;
                 if (selectedOsmObject.hasKey(combox.getName())){
                     combox.setSelectedItem(selectedOsmObject.get(combox.getName()));
                 }
@@ -328,8 +328,8 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
 
                     if (fields.get(i).equals(c)) {
                         return i;
-                    } else if (fields.get(i) instanceof AutoCompletingComboBox) {
-                        AutoCompletingComboBox ac = (AutoCompletingComboBox) fields.get(i);
+                    } else if (fields.get(i) instanceof AutoCompComboBox) {
+                        AutoCompComboBox<?> ac = (AutoCompComboBox<?>) fields.get(i);
                         if (Arrays.asList(ac.getComponents()).contains(c)) {
                             return i;
                         }
@@ -350,7 +350,7 @@ public class AddressDialog extends ExtendedDialog implements ChangeListener {
         }
     }
 
-    protected String getAutoCompletingComboBoxValue(AutoCompletingComboBox box) {
+    protected String getAutoCompletingComboBoxValue(AutoCompComboBox<?> box) {
         Object item = box.getSelectedItem();
         if (item != null) {
             if (item instanceof String) {


### PR DESCRIPTION
This updates the plugin to r18173 for the autocombobox changes.

It also cleans up the build.gradle.kts file, as the JOSM gradle plugin automatically adds the dependencies, or the dependency is part of another plugin (i.e., ejml and log4j).

This depends upon JOSM [#21517](https://josm.openstreetmap.de/ticket/21517) for an updated log4j.